### PR TITLE
feat: reset subversions when bump is greater than minor

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -42,13 +42,17 @@ the pre-release identifier or local version segment::
   Usage: bump [OPTIONS] [INPUT] [OUTPUT]
 
   Options:
-    -M, --major     Bump major number
-    -m, --minor     Bump minor number
-    -p, --patch     Bump patch number
+    -M, --major     Bump major number. Ex.: 1.8.3 -> 2.8.3
+    -m, --minor     Bump minor number. Ex.: 1.8.3 -> 1.9.3
+    -p, --patch     Bump patch number. Ex.: 1.8.3 -> 1.8.4
+    -c, --clear     Zero subversions. Ex.: Major bump from 1.8.3 will be 2.0.0
+                    instead of 2.8.3
     --pre TEXT      Set the pre-release identifier
     --local TEXT    Set the local version segment
     --canonicalize  Canonicalize the new version
     --help          Show this message and exit.
+
+The `--clear` option should be used alongside with minor or major bump.
 
 You can configure these options by setting them in a ``.bump`` or ``setup.cfg``
 configuration file as well, so you don't have to specify them every time::
@@ -58,3 +62,4 @@ configuration file as well, so you don't have to specify them every time::
   input = some_directory/__file__.py
   minor = true
   patch = false
+  clear = true

--- a/README.rst
+++ b/README.rst
@@ -46,7 +46,7 @@ the pre-release identifier or local version segment::
     -m, --minor     Bump minor number. Ex.: 1.2.3 -> 1.3.3
     -p, --patch     Bump patch number. Ex.: 1.2.3 -> 1.2.4
     -r, --reset     Zero subversions. Ex.: Major bump from 1.2.3 will be 2.0.0
-                    instead of 2..3
+                    instead of 2.1.3
     --pre TEXT      Set the pre-release identifier
     --local TEXT    Set the local version segment
     --canonicalize  Canonicalize the new version

--- a/README.rst
+++ b/README.rst
@@ -45,7 +45,7 @@ the pre-release identifier or local version segment::
     -M, --major     Bump major number. Ex.: 1.2.3 -> 2.2.3
     -m, --minor     Bump minor number. Ex.: 1.2.3 -> 1.3.3
     -p, --patch     Bump patch number. Ex.: 1.2.3 -> 1.2.4
-    -r, --reset     Zero subversions. Ex.: Major bump from 1.2.3 will be 2.0.0
+    -r, --reset     Reset subversions. Ex.: Major bump from 1.2.3 will be 2.0.0
                     instead of 2.2.3
     --pre TEXT      Set the pre-release identifier
     --local TEXT    Set the local version segment

--- a/README.rst
+++ b/README.rst
@@ -42,9 +42,9 @@ the pre-release identifier or local version segment::
   Usage: bump [OPTIONS] [INPUT] [OUTPUT]
 
   Options:
-    -M, --major     Bump major number. Ex.: 1.8.3 -> 2.8.3
-    -m, --minor     Bump minor number. Ex.: 1.8.3 -> 1.9.3
-    -p, --patch     Bump patch number. Ex.: 1.8.3 -> 1.8.4
+    -M, --major     Bump major number. Ex.: 1.2.3 -> 2.2.3
+    -m, --minor     Bump minor number. Ex.: 1.2.3 -> 1.3.3
+    -p, --patch     Bump patch number. Ex.: 1.2.3 -> 1.2.4
     -c, --clear     Zero subversions. Ex.: Major bump from 1.8.3 will be 2.0.0
                     instead of 2.8.3
     --pre TEXT      Set the pre-release identifier

--- a/README.rst
+++ b/README.rst
@@ -45,14 +45,14 @@ the pre-release identifier or local version segment::
     -M, --major     Bump major number. Ex.: 1.2.3 -> 2.2.3
     -m, --minor     Bump minor number. Ex.: 1.2.3 -> 1.3.3
     -p, --patch     Bump patch number. Ex.: 1.2.3 -> 1.2.4
-    -c, --clear     Zero subversions. Ex.: Major bump from 1.8.3 will be 2.0.0
-                    instead of 2.8.3
+    -r, --reset     Zero subversions. Ex.: Major bump from 1.2.3 will be 2.0.0
+                    instead of 2..3
     --pre TEXT      Set the pre-release identifier
     --local TEXT    Set the local version segment
     --canonicalize  Canonicalize the new version
     --help          Show this message and exit.
 
-The `--clear` option should be used alongside with minor or major bump.
+The `--reset` option should be used alongside with minor or major bump.
 
 You can configure these options by setting them in a ``.bump`` or ``setup.cfg``
 configuration file as well, so you don't have to specify them every time::
@@ -62,4 +62,4 @@ configuration file as well, so you don't have to specify them every time::
   input = some_directory/__file__.py
   minor = true
   patch = false
-  clear = true
+  reset = true

--- a/README.rst
+++ b/README.rst
@@ -46,7 +46,7 @@ the pre-release identifier or local version segment::
     -m, --minor     Bump minor number. Ex.: 1.2.3 -> 1.3.3
     -p, --patch     Bump patch number. Ex.: 1.2.3 -> 1.2.4
     -r, --reset     Zero subversions. Ex.: Major bump from 1.2.3 will be 2.0.0
-                    instead of 2.1.3
+                    instead of 2.2.3
     --pre TEXT      Set the pre-release identifier
     --local TEXT    Set the local version segment
     --canonicalize  Canonicalize the new version

--- a/bump.py
+++ b/bump.py
@@ -96,13 +96,28 @@ def find_version(input_string):
 
 @click.command()
 @click.option(
-    "--major", "-M", "major", flag_value=True, default=None, help="Bump major number. Ex.: 1.2.3 -> 2.2.3"
+    "--major",
+    "-M",
+    "major",
+    flag_value=True,
+    default=None,
+    help="Bump major number. Ex.: 1.2.3 -> 2.2.3",
 )
 @click.option(
-    "--minor", "-m", "minor", flag_value=True, default=None, help="Bump minor number. Ex.: 1.2.3 -> 1.3.3"
+    "--minor",
+    "-m",
+    "minor",
+    flag_value=True,
+    default=None,
+    help="Bump minor number. Ex.: 1.2.3 -> 1.3.3",
 )
 @click.option(
-    "--patch", "-p", "patch", flag_value=True, default=None, help="Bump patch number. Ex.: 1.2.3 -> 1.2.4"
+    "--patch",
+    "-p",
+    "patch",
+    flag_value=True,
+    default=None,
+    help="Bump patch number. Ex.: 1.2.3 -> 1.2.4",
 )
 @click.option(
     "--reset",

--- a/bump.py
+++ b/bump.py
@@ -64,8 +64,11 @@ class SemVer(object):
     def bump(self, major=False, minor=False, patch=False, pre=None, local=None):
         if major:
             self.major += 1
+            self.minor = 0
+            self.patch = 0
         if minor:
             self.minor += 1
+            self.patch = 0
         if patch:
             self.patch += 1
         if pre:
@@ -111,7 +114,7 @@ def main(input, output, major, minor, patch, pre, local, canonicalize):
 
     major = major or config.getboolean("bump", "major", fallback=False)
     minor = minor or config.getboolean("bump", "minor", fallback=False)
-    patch = patch or config.getboolean("bump", "patch", fallback=True)
+    patch = patch or config.getboolean("bump", "patch", fallback=False)
     input = input or click.File("rb")(config.get("bump", "input", fallback="setup.py"))
     output = output or click.File("wb")(input.name)
     canonicalize = canonicalize or config.get("bump", "canonicalize", fallback=False)

--- a/bump.py
+++ b/bump.py
@@ -62,16 +62,16 @@ class SemVer(object):
         )
 
     def bump(
-        self, major=False, minor=False, patch=False, pre=None, local=None, clear=False
+        self, major=False, minor=False, patch=False, pre=None, local=None, reset=False
     ):
         if major:
             self.major += 1
-            if clear:
+            if reset:
                 self.minor = 0
                 self.patch = 0
         if minor:
             self.minor += 1
-            if clear:
+            if reset:
                 self.patch = 0
         if patch:
             self.patch += 1
@@ -96,21 +96,21 @@ def find_version(input_string):
 
 @click.command()
 @click.option(
-    "--major", "-M", "major", flag_value=True, default=None, help="Bump major number"
+    "--major", "-M", "major", flag_value=True, default=None, help="Bump major number. Ex.: 1.2.3 -> 2.2.3"
 )
 @click.option(
-    "--minor", "-m", "minor", flag_value=True, default=None, help="Bump minor number"
+    "--minor", "-m", "minor", flag_value=True, default=None, help="Bump minor number. Ex.: 1.2.3 -> 1.3.3"
 )
 @click.option(
-    "--patch", "-p", "patch", flag_value=True, default=None, help="Bump patch number"
+    "--patch", "-p", "patch", flag_value=True, default=None, help="Bump patch number. Ex.: 1.2.3 -> 1.2.4"
 )
 @click.option(
-    "--clear",
-    "-c",
-    "clear",
+    "--reset",
+    "-r",
+    "reset",
     flag_value=True,
     default=None,
-    help="Zero subversions. Ex.: Major bump from 1.8.3 will be 2.0.0 instead of 2.8.3",
+    help="Reset subversions. Ex.: Major bump from 1.2.3 will be 2.0.0 instead of 2.2.3",
 )
 @click.option("--pre", help="Set the pre-release identifier")
 @click.option("--local", help="Set the local version segment")
@@ -119,7 +119,7 @@ def find_version(input_string):
 )
 @click.argument("input", type=click.File("rb"), default=None, required=False)
 @click.argument("output", type=click.File("wb"), default=None, required=False)
-def main(input, output, major, minor, patch, clear, pre, local, canonicalize):
+def main(input, output, major, minor, patch, reset, pre, local, canonicalize):
 
     config = configparser.RawConfigParser()
     config.read([".bump", "setup.cfg"])
@@ -127,7 +127,7 @@ def main(input, output, major, minor, patch, clear, pre, local, canonicalize):
     major = major or config.getboolean("bump", "major", fallback=False)
     minor = minor or config.getboolean("bump", "minor", fallback=False)
     patch = patch or config.getboolean("bump", "patch", fallback=False)
-    clear = clear or config.getboolean("bump", "clear", fallback=False)
+    reset = reset or config.getboolean("bump", "reset", fallback=False)
     input = input or click.File("rb")(config.get("bump", "input", fallback="setup.py"))
     output = output or click.File("wb")(input.name)
     canonicalize = canonicalize or config.get("bump", "canonicalize", fallback=False)
@@ -140,7 +140,7 @@ def main(input, output, major, minor, patch, clear, pre, local, canonicalize):
         sys.exit(1)
 
     version = SemVer.parse(version_string)
-    version.bump(major, minor, patch, pre, local, clear)
+    version.bump(major, minor, patch, pre, local, reset)
     version_string = str(version)
     if canonicalize:
         version_string = canonicalize_version(version_string)

--- a/bump.py
+++ b/bump.py
@@ -61,14 +61,16 @@ class SemVer(object):
             major=int(major), minor=int(minor), patch=int(patch), pre=pre, local=local
         )
 
-    def bump(self, major=False, minor=False, patch=False, pre=None, local=None):
+    def bump(self, major=False, minor=False, patch=False, pre=None, local=None, clear=False):
         if major:
             self.major += 1
-            self.minor = 0
-            self.patch = 0
+            if clear:
+                self.minor = 0
+                self.patch = 0
         if minor:
             self.minor += 1
-            self.patch = 0
+            if clear:
+                self.patch = 0
         if patch:
             self.patch += 1
         if pre:
@@ -100,6 +102,10 @@ def find_version(input_string):
 @click.option(
     "--patch", "-p", "patch", flag_value=True, default=None, help="Bump patch number"
 )
+@click.option(
+    "--clear", "-c", "clear", flag_value=True, default=None,
+    help="Zero subversions. Ex.: Major bump from 1.8.3 will be 2.0.0 instead of 2.8.3"
+)
 @click.option("--pre", help="Set the pre-release identifier")
 @click.option("--local", help="Set the local version segment")
 @click.option(
@@ -107,7 +113,7 @@ def find_version(input_string):
 )
 @click.argument("input", type=click.File("rb"), default=None, required=False)
 @click.argument("output", type=click.File("wb"), default=None, required=False)
-def main(input, output, major, minor, patch, pre, local, canonicalize):
+def main(input, output, major, minor, patch, clear, pre, local, canonicalize):
 
     config = configparser.RawConfigParser()
     config.read([".bump", "setup.cfg"])
@@ -115,6 +121,7 @@ def main(input, output, major, minor, patch, pre, local, canonicalize):
     major = major or config.getboolean("bump", "major", fallback=False)
     minor = minor or config.getboolean("bump", "minor", fallback=False)
     patch = patch or config.getboolean("bump", "patch", fallback=False)
+    clear = clear or config.getboolean("bump", "clear", fallback=False)
     input = input or click.File("rb")(config.get("bump", "input", fallback="setup.py"))
     output = output or click.File("wb")(input.name)
     canonicalize = canonicalize or config.get("bump", "canonicalize", fallback=False)
@@ -127,7 +134,7 @@ def main(input, output, major, minor, patch, pre, local, canonicalize):
         sys.exit(1)
 
     version = SemVer.parse(version_string)
-    version.bump(major, minor, patch, pre, local)
+    version.bump(major, minor, patch, pre, local, clear)
     version_string = str(version)
     if canonicalize:
         version_string = canonicalize_version(version_string)

--- a/bump.py
+++ b/bump.py
@@ -61,7 +61,9 @@ class SemVer(object):
             major=int(major), minor=int(minor), patch=int(patch), pre=pre, local=local
         )
 
-    def bump(self, major=False, minor=False, patch=False, pre=None, local=None, clear=False):
+    def bump(
+        self, major=False, minor=False, patch=False, pre=None, local=None, clear=False
+    ):
         if major:
             self.major += 1
             if clear:
@@ -103,8 +105,12 @@ def find_version(input_string):
     "--patch", "-p", "patch", flag_value=True, default=None, help="Bump patch number"
 )
 @click.option(
-    "--clear", "-c", "clear", flag_value=True, default=None,
-    help="Zero subversions. Ex.: Major bump from 1.8.3 will be 2.0.0 instead of 2.8.3"
+    "--clear",
+    "-c",
+    "clear",
+    flag_value=True,
+    default=None,
+    help="Zero subversions. Ex.: Major bump from 1.8.3 will be 2.0.0 instead of 2.8.3",
 )
 @click.option("--pre", help="Set the pre-release identifier")
 @click.option("--local", help="Set the local version segment")

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name="bump",
-    version="4.0.0",
+    version="1.3.0",
     description="Bumps package version numbers",
     long_description=open("README.rst").read(),
     license="MIT",

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name="bump",
-    version="1.2.0",
+    version="4.0.0",
     description="Bumps package version numbers",
     long_description=open("README.rst").read(),
     license="MIT",

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name="bump",
-    version="1.3.0",
+    version="1.3.1",
     description="Bumps package version numbers",
     long_description=open("README.rst").read(),
     license="MIT",

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name="bump",
-    version="1.3.1",
+    version="1.3.0",
     description="Bumps package version numbers",
     long_description=open("README.rst").read(),
     license="MIT",

--- a/test.py
+++ b/test.py
@@ -71,10 +71,12 @@ def test_bump_patch():
     version.bump(patch=True)
     check_version(version, 1, 2, 4, None, None)
 
+
 def test_bump_patch_with_reset():
     version = SemVer(major=1, minor=2, patch=3)
     version.bump(patch=True)
     check_version(version, 1, 2, 4, None, None)
+
 
 def test_bump_pre():
     version = SemVer(major=1, minor=2, patch=3)

--- a/test.py
+++ b/test.py
@@ -71,6 +71,10 @@ def test_bump_patch():
     version.bump(patch=True)
     check_version(version, 1, 2, 4, None, None)
 
+def test_bump_patch_with_clear():
+    version = SemVer(major=1, minor=2, patch=3, clear=True)
+    version.bump(patch=True)
+    check_version(version, 1, 2, 4, None, None)
 
 def test_bump_pre():
     version = SemVer(major=1, minor=2, patch=3)

--- a/test.py
+++ b/test.py
@@ -74,7 +74,7 @@ def test_bump_patch():
 
 def test_bump_patch_with_reset():
     version = SemVer(major=1, minor=2, patch=3)
-    version.bump(patch=True)
+    version.bump(patch=True, reset=True)
     check_version(version, 1, 2, 4, None, None)
 
 

--- a/test.py
+++ b/test.py
@@ -47,20 +47,24 @@ def test_bump_major():
     version.bump(major=True)
     check_version(version, 2, 2, 3, None, None)
 
+
 def test_bump_major_with_clear():
     version = SemVer(major=1, minor=2, patch=3)
     version.bump(major=True, clear=True)
     check_version(version, 2, 0, 0, None, None)
+
 
 def test_bump_minor():
     version = SemVer(major=1, minor=2, patch=3)
     version.bump(minor=True)
     check_version(version, 1, 3, 3, None, None)
 
+
 def test_bump_minor_with_clear():
     version = SemVer(major=1, minor=2, patch=3)
     version.bump(minor=True, clear=True)
     check_version(version, 1, 3, 0, None, None)
+
 
 def test_bump_patch():
     version = SemVer(major=1, minor=2, patch=3)

--- a/test.py
+++ b/test.py
@@ -48,9 +48,9 @@ def test_bump_major():
     check_version(version, 2, 2, 3, None, None)
 
 
-def test_bump_major_with_clear():
+def test_bump_major_with_reset():
     version = SemVer(major=1, minor=2, patch=3)
-    version.bump(major=True, clear=True)
+    version.bump(major=True, reset=True)
     check_version(version, 2, 0, 0, None, None)
 
 
@@ -60,9 +60,9 @@ def test_bump_minor():
     check_version(version, 1, 3, 3, None, None)
 
 
-def test_bump_minor_with_clear():
+def test_bump_minor_with_reset():
     version = SemVer(major=1, minor=2, patch=3)
-    version.bump(minor=True, clear=True)
+    version.bump(minor=True, reset=True)
     check_version(version, 1, 3, 0, None, None)
 
 
@@ -71,8 +71,8 @@ def test_bump_patch():
     version.bump(patch=True)
     check_version(version, 1, 2, 4, None, None)
 
-def test_bump_patch_with_clear():
-    version = SemVer(major=1, minor=2, patch=3, clear=True)
+def test_bump_patch_with_reset():
+    version = SemVer(major=1, minor=2, patch=3)
     version.bump(patch=True)
     check_version(version, 1, 2, 4, None, None)
 

--- a/test.py
+++ b/test.py
@@ -47,12 +47,20 @@ def test_bump_major():
     version.bump(major=True)
     check_version(version, 2, 2, 3, None, None)
 
+def test_bump_major_with_clear():
+    version = SemVer(major=1, minor=2, patch=3)
+    version.bump(major=True, clear=True)
+    check_version(version, 2, 0, 0, None, None)
 
 def test_bump_minor():
     version = SemVer(major=1, minor=2, patch=3)
     version.bump(minor=True)
     check_version(version, 1, 3, 3, None, None)
 
+def test_bump_minor_with_clear():
+    version = SemVer(major=1, minor=2, patch=3)
+    version.bump(minor=True, clear=True)
+    check_version(version, 1, 3, 0, None, None)
 
 def test_bump_patch():
     version = SemVer(major=1, minor=2, patch=3)


### PR DESCRIPTION
This adds the clear option when we bump a minor or a major.

For example, when we have to bump a minor.
Bumping a minor from 1.8.3 must be 1.9.0, not 1.9.3.
The same is valid for a major, which in the previous example must be
2.0.0, not 2.9.3.

Fixes #15.