### PR TITLE
setup: bump click to >= 8

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
     zip_safe=False,
     py_modules=["bump"],
     install_requires=[
-        "click>=6,<8",
+        "click>=8",
         "configparser ; python_version<'3'",
         "first",
         "packaging>=17.1",


### PR DESCRIPTION
Tested locally; nothing seems to be amiss. I also cross-checked
all of `bump`'s uses of `click`'s APIs against the 8.0 docs.