### PR TITLE
`pyproject.toml` support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.egg-info
 build/
 dist/
+env/

--- a/bump.py
+++ b/bump.py
@@ -18,10 +18,12 @@ class Config:
 
         self.toml_config = {}
         if os.path.exists("pyproject.toml"):
-            self.toml_config = toml.load(["pyproject.toml"]).get("tool.bump", {})
+            self.toml_config = (
+                toml.load("pyproject.toml").get("tool", {}).get("bump", {})
+            )
 
     def get(self, key, coercer=str, default=None):
-        candidate = self.toml_config.get(key, default)
+        candidate = self.toml_config.get(key)
         if candidate is not None:
             # No coercion needed for TOML, since values are strongly typed.
             return candidate

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name="bump",
-    version="1.3.1",
+    version="1.3.2",
     description="Bumps package version numbers",
     long_description=open("README.rst").read(),
     license="MIT",
@@ -23,6 +23,7 @@ setup(
         "click>=6,<9",
         "first",
         "packaging>=17.1",
+        "toml",
     ],
     extras_require={
         "dev": [


### PR DESCRIPTION
Teaches bump how to read `tool.bump` from a project's `pyproject.toml`.

Needs tests.